### PR TITLE
Stop stdin reader from spinning after EOF

### DIFF
--- a/server.go
+++ b/server.go
@@ -81,7 +81,7 @@ func server(args []string) int {
 				if err == io.EOF {
 					enc.Encode(&msg{Name: "close"})
 				}
-				continue
+				break
 			}
 			err = enc.Encode(&msg{Name: "stdin", Data: b[:n]})
 			if err != nil {


### PR DESCRIPTION
The stdin reader goroutine in server() used continue on read errors. After stdin reaches EOF, os.Stdin.Read keeps returning EOF immediately, so the loop busy-spins and repeatedly encodes a close message, burning CPU.

Break out of the loop once a read error (including EOF) occurs.