### PR TITLE
Read environ handshake before starting input reader

### DIFF
--- a/client.go
+++ b/client.go
@@ -43,13 +43,20 @@ func client(addr string, args []string) int {
 	defer errw.Close()
 	cmd.Stderr = errw
 
+	var environ []string
+	err = dec.Decode(&environ)
+	if err != nil {
+		enc.Encode(&msg{Name: "error", Error: fmt.Sprintf("cannot execute command: %v", makeCmdLine(args))})
+		return 1
+	}
+	cmd.Env = environ
+
 	go func() {
 		defer inw.Close()
 	in_loop:
 		for {
 			var m msg
-			err = dec.Decode(&m)
-			if err != nil {
+			if err := dec.Decode(&m); err != nil {
 				return
 			}
 			switch m.Name {
@@ -68,14 +75,6 @@ func client(addr string, args []string) int {
 			}
 		}
 	}()
-
-	var environ []string
-	err = dec.Decode(&environ)
-	if err != nil {
-		enc.Encode(&msg{Name: "error", Error: fmt.Sprintf("cannot execute command: %v", makeCmdLine(args))})
-		return 1
-	}
-	cmd.Env = environ
 
 	err = cmd.Run()
 


### PR DESCRIPTION
The input reader goroutine decoded from the shared gob.Decoder while the main goroutine also decoded the initial environ handshake from it. The two concurrent Decode calls race and the handshake []string could be consumed by the reader goroutine, corrupting the protocol. The goroutine also clobbered the shared err variable.

Decode the environ handshake before launching the reader goroutine, and use a local err inside the goroutine.