### PR TITLE
Guard shared gob encoder with a mutex

### DIFF
--- a/client.go
+++ b/client.go
@@ -21,7 +21,7 @@ func client(addr string, args []string) int {
 	}
 	defer conn.Close()
 
-	enc, dec := gob.NewEncoder(conn), gob.NewDecoder(conn)
+	enc, dec := newMsgEncoder(conn), gob.NewDecoder(conn)
 
 	cmd := exec.Command(args[0], args[1:]...)
 

--- a/server.go
+++ b/server.go
@@ -55,7 +55,7 @@ func server(args []string) int {
 	}
 	defer conn.Close()
 
-	enc, dec := gob.NewEncoder(conn), gob.NewDecoder(conn)
+	enc, dec := newMsgEncoder(conn), gob.NewDecoder(conn)
 
 	err = enc.Encode(os.Environ())
 	if err != nil {

--- a/util.go
+++ b/util.go
@@ -6,6 +6,7 @@ package main
 import (
 	"encoding/gob"
 	"io"
+	"sync"
 	"syscall"
 )
 
@@ -16,7 +17,25 @@ type msg struct {
 	Data  []byte
 }
 
-func msgWrite(enc *gob.Encoder, typ string) io.WriteCloser {
+// msgEncoder is a gob encoder that is safe for concurrent use, since the
+// stdout/stderr writers and the main goroutine all encode to a single
+// connection.
+type msgEncoder struct {
+	mu  sync.Mutex
+	enc *gob.Encoder
+}
+
+func newMsgEncoder(w io.Writer) *msgEncoder {
+	return &msgEncoder{enc: gob.NewEncoder(w)}
+}
+
+func (e *msgEncoder) Encode(v interface{}) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.enc.Encode(v)
+}
+
+func msgWrite(enc *msgEncoder, typ string) io.WriteCloser {
 	r, w := io.Pipe()
 	go func() {
 		defer r.Close()

--- a/util_test.go
+++ b/util_test.go
@@ -10,7 +10,7 @@ func TestMsgWrite(t *testing.T) {
 	tests := []string{"foo", "bar", "baz"}
 
 	pr, pw := io.Pipe()
-	wc := msgWrite(gob.NewEncoder(pw), "test")
+	wc := msgWrite(newMsgEncoder(pw), "test")
 
 	go func() {
 		for _, test := range tests {


### PR DESCRIPTION
The stdout and stderr writer goroutines and the main goroutine all called Encode on the same gob.Encoder concurrently (both in the client and the server). gob.Encoder is not safe for concurrent use, so this races and can interleave/corrupt the gob stream.

Wrap the encoder in a small mutex-protected type used by all writers.