### PR TITLE
Stop signal relay before closing channel

### DIFF
--- a/server.go
+++ b/server.go
@@ -70,7 +70,10 @@ func server(args []string) int {
 			enc.Encode(&msg{Name: "ctrlc"})
 		}
 	}()
-	defer close(sc)
+	defer func() {
+		signal.Stop(sc)
+		close(sc)
+	}()
 
 	go func() {
 		var b [256]byte


### PR DESCRIPTION
The signal channel was closed with defer close(sc) while it was still registered via signal.Notify. If a signal is delivered around shutdown, the runtime could send on the closed channel and panic.

Call signal.Stop before closing so no further sends can happen.