### PR TITLE
Avoid nil process deref on early ctrlc

### DIFF
--- a/client.go
+++ b/client.go
@@ -63,6 +63,9 @@ func client(addr string, args []string) int {
 			case "close":
 				inw.Close()
 			case "ctrlc":
+				if cmd.Process == nil {
+					continue
+				}
 				if runtime.GOOS == "windows" {
 					// windows doesn't support os.Interrupt
 					exec.Command("taskkill", "/F", "/T", "/PID", fmt.Sprint(cmd.Process.Pid)).Run()


### PR DESCRIPTION
The input reader goroutine handles a ctrlc message by dereferencing cmd.Process, but it is started before cmd.Run() launches the process. A ctrlc arriving in that window would panic with a nil pointer dereference.

Skip the ctrlc handling when cmd.Process is still nil.