### PR TITLE
Flush stdout and stderr before sending exit code

### DIFF
--- a/client.go
+++ b/client.go
@@ -90,6 +90,10 @@ func client(addr string, args []string) int {
 		code = 0
 	}
 
+	// flush any buffered stdout/stderr before reporting the exit code
+	outw.Close()
+	errw.Close()
+
 	err = enc.Encode(&msg{Name: "exit", Exit: code})
 	if err != nil {
 		enc.Encode(&msg{Name: "error", Error: fmt.Sprintf("cannot detect exit code: %v", makeCmdLine(args))})

--- a/util.go
+++ b/util.go
@@ -35,9 +35,30 @@ func (e *msgEncoder) Encode(v interface{}) error {
 	return e.enc.Encode(v)
 }
 
+// msgWriter is an io.WriteCloser whose Close blocks until every byte written
+// has been encoded, so callers can flush all output before sending a final
+// message such as the exit code.
+type msgWriter struct {
+	w    *io.PipeWriter
+	done chan struct{}
+	once sync.Once
+}
+
+func (mw *msgWriter) Write(p []byte) (int, error) {
+	return mw.w.Write(p)
+}
+
+func (mw *msgWriter) Close() error {
+	err := mw.w.Close()
+	mw.once.Do(func() { <-mw.done })
+	return err
+}
+
 func msgWrite(enc *msgEncoder, typ string) io.WriteCloser {
 	r, w := io.Pipe()
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		defer r.Close()
 		var b [4096]byte
 		for {
@@ -51,7 +72,7 @@ func msgWrite(enc *msgEncoder, typ string) io.WriteCloser {
 			}
 		}
 	}()
-	return w
+	return &msgWriter{w: w, done: done}
 }
 
 func makeCmdLine(args []string) string {


### PR DESCRIPTION
The client sent the exit message as soon as cmd.Run() returned, but the stdout/stderr writer goroutines might not have finished encoding the final chunk of output. Since the server returns immediately on the exit message, trailing output could be dropped.

Make msgWrite's Close block until the writer goroutine has drained, and close the stdout/stderr writers before encoding the exit code.